### PR TITLE
added travis and bumped versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+---
+language: python
+sudo: required
+services:
+  - docker
+script: tox

--- a/behave/environment.py
+++ b/behave/environment.py
@@ -1,5 +1,0 @@
-from behave_pytest.hook import install_pytest_asserts
-
-
-def before_all(context):
-    install_pytest_asserts()

--- a/behave/steps/marathon_steps.py
+++ b/behave/steps/marathon_steps.py
@@ -77,5 +77,5 @@ def marathon_should_not_kill_anything(context):
     # Check for a little while, in case the effect is delayed.
     for _ in xrange(10):
         task_ids = set([t.id for t in app.tasks])
-        assert context.task_ids_before_failover == task_ids
+        assert context.task_ids_before_failover == task_ids, (context.task_ids_before_failover, task_ids)
         time.sleep(1)

--- a/dockerfiles/marathon/Dockerfile
+++ b/dockerfiles/marathon/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:trusty
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN echo "deb http://repos.mesosphere.com/ubuntu trusty-testing main" > /etc/apt/sources.list.d/mesosphere-testing.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 81026D0004C44CF7EF55ADF8DF7D54CBE56151BF
-RUN apt-get update && apt-get -y install mesos=1.0.0-1.0.73.rc2.ubuntu1404
+RUN apt-get update && apt-get -y install mesos=1.0.1-2.0.93.ubuntu1404
 
 # Install Java 8 PPA
 RUN apt-get install -y software-properties-common
@@ -26,6 +26,6 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
 RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
-RUN apt-get -y install libsasl2-modules marathon=1.2.0-1.0.486.ubuntu1404
+RUN apt-get -y install libsasl2-modules marathon=1.3.3-1.0.529.ubuntu1404
 
 EXPOSE 8080

--- a/tox.ini
+++ b/tox.ini
@@ -6,20 +6,21 @@ basepython = python2.7
 
 [testenv:inside_container]
 deps =
-	behave==1.2.4
-	behave-pytest==0.1.1
-	marathon==0.8.3
+    pytest==3.0.3
+    behave==1.2.4
+    behave-pytest==0.1.1
+    marathon==0.8.6
 changedir=behave/
 commands =
-	python -m behave {posargs}
+    python -m behave {posargs}
 
 [testenv:outside_container]
 basepython = python2.7
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 deps =
-	docker-compose==1.3.0
+    docker-compose==1.3.0
 commands =
-	docker-compose pull --allow-insecure-ssl
-	docker-compose --verbose build
-	docker-compose up -d zookeeper mesosmaster mesosslave marathon
-	docker-compose run --rm behave tox -e inside_container -- --no-capture {posargs}
+    docker-compose pull --allow-insecure-ssl
+    docker-compose --verbose build
+    docker-compose up -d zookeeper mesosmaster mesosslave marathon
+    docker-compose run --rm behave tox -e inside_container -- --no-capture {posargs}


### PR DESCRIPTION
This adds travis integration so it is very "obvious" that it fails.

Also I had to get rid of the `install_pytest_asserts` because of some circular import issue?

Also bumped all versions to latest just in case this has been fixed in the mean time.
